### PR TITLE
Fix issue regarding the #options HTML id.

### DIFF
--- a/pages/filter-cheatsheet.html
+++ b/pages/filter-cheatsheet.html
@@ -455,7 +455,7 @@ title=Adblock Plus filters explained
       <p>{{s46 This character indicates that the following text defines filter option.}}</p>
     </div>
     <div class="typeOption">
-      <h4><a href="#options">{{s47 Type option}}</a></h4>
+      <h4><a href="#filter-options">{{s47 Type option}}</a></h4>
       <p>
         {{s48 Type options define request types to be blocked. Common type options are
         <code>script</code> or <code>image</code> indicating that only
@@ -464,7 +464,7 @@ title=Adblock Plus filters explained
       </p>
     </div>
     <div class="domainOption">
-      <h4><a href="#options">{{s49 Domain option}}</a></h4>
+      <h4><a href="#filter-options">{{s49 Domain option}}</a></h4>
       <p>
         {{s50 Domain option restricts the filter to a set of domains (here <code>example.com</code>).
         It also allows to disable the rule on some domains (here on <code>foo.example.com</code>).}}
@@ -507,7 +507,7 @@ title=Adblock Plus filters explained
       <p>{{s61 This part of the rule defines which addresses it is applied to, it is structured the same as for <a href="#blocking">blocking rules</a>.}}</p>
     </div>
     <div class="typeOption">
-      <h4><a href="#options">{{s47 Type option}}</a></h4>
+      <h4><a href="#filter-options">{{s47 Type option}}</a></h4>
       <p>
         {{s63 This type option prevents the exception from being applied to scripts.}}
       </p>
@@ -532,7 +532,7 @@ title=Adblock Plus filters explained
       <p>{{s61 This part of the rule defines which addresses it is applied to, it is structured the same as for <a href="#blocking">blocking rules</a>.}}</p>
     </div>
     <div class="typeOption">
-      <h4><a href="#options">{{s47 Type option}}</a></h4>
+      <h4><a href="#filter-options">{{s47 Type option}}</a></h4>
       <p>
         {{s74 This special type option indicates that Adblock Plus should be completely disabled on pages that this rule applies to.}}
       </p>
@@ -563,7 +563,7 @@ title=Adblock Plus filters explained
   </div>
 </div>
 
-<h2 id="options">{{s86 Filter options}}</h2>
+<h2 id="filter-options">{{s86 Filter options}}</h2>
 
 <table>
   <col class="option">


### PR DESCRIPTION
Indeed, before this patch, we had 2 titles with the "options" id which caused the TOC to not "redirects" to the right section.